### PR TITLE
fix: correct stylelint.config.js

### DIFF
--- a/stylelint.config.js
+++ b/stylelint.config.js
@@ -2,20 +2,26 @@ module.exports = {
   extends: ['stylelint-config-sass-guidelines', 'stylelint-config-prettier'],
   plugins: ['stylelint-scss'],
   rules: {
-    'at-rule-no-unknown': [
+    'scss/at-rule-no-unknown': [
       true,
       {
         ignoreAtRules: [
-          /apply/,
-          /layer/,
-          /responsive/,
-          /screen/,
-          /tailwind/,
-          /variants/
+          'apply',
+          'layer',
+          'responsive',
+          'screen',
+          'tailwind',
+          'variants'
         ]
       }
     ],
     'declaration-empty-line-before': 'never',
-    'max-nesting-depth': 4
+    'max-nesting-depth': 4,
+    'selector-no-qualifying-type': [
+      true,
+      {
+        ignore: 'attribute'
+      }
+    ]
   }
 }


### PR DESCRIPTION
- after integrating Sass, the 'at-rule-no-unknown' rule needs to be prefixed with 'scss/' and ignoreAtRules must be strings
- add 'select-no-qualifying-type' to ignore abbr[title] override of internal tailwindcss rules