### PR TITLE
Fix: Future Isn't Static Home Page Section Overlay

### DIFF
--- a/pages/index.vue
+++ b/pages/index.vue
@@ -92,7 +92,7 @@
         </p>
       </section>
       <img
-        class="absolute bottom-0"
+        class="absolute bottom-0 w-full"
         src="/images/the-future-isnt-static-cover.svg"
       />
     </SectionVideo>


### PR DESCRIPTION
- Fixed text overlay not taking 100% width of screen on larger breakpoints