### PR TITLE
fix: Future Isn't Static Video

### DIFF
--- a/content/videos/the-future-isnt-static.json
+++ b/content/videos/the-future-isnt-static.json
@@ -2,6 +2,6 @@
   "title": "The Future isn’t Static",
   "height": 2160,
   "poster": "the-future-isnt-static-poster",
-  "src": "/videos/the-future-isnt-static",
+  "src": "https://player.vimeo.com/video/539869996?background=1&autoplay=1&loop=1",
   "width": 3840
 }


### PR DESCRIPTION
- hotfix to revert Future Isn't Static Video back to original source until component is updated/fixed to allow for webm/mp4 use.